### PR TITLE
Modify job names in workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    name: Build Release
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -13,7 +13,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  sanity:
+    name: Sanity Check
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Job names are used for PR checks instead of the workflow names.